### PR TITLE
Fix iterators and tests

### DIFF
--- a/nbdime/tests/test_server_extension.py
+++ b/nbdime/tests/test_server_extension.py
@@ -73,15 +73,13 @@ def test_git_difftool(git_repo2, server_extension_app):
     # Extract config data
     match = _re_config.search(r.text)
     data = json.loads(match.group(1))
-    assert data.pop("mathjaxUrl", "").endswith("MathJax.js")
     assert data == {
         "base": "git:",
         "baseUrl": "/nbdime",
         "closable": False,
         "remote": "",
         "savable": False,
-        "hideUnchanged": True,
-        "mathjaxConfig": "TeX-AMS-MML_HTMLorMML-full,Safe",
+        "hideUnchanged": True
     }
 
 

--- a/nbdime/tests/test_web.py
+++ b/nbdime/tests/test_web.py
@@ -126,6 +126,3 @@ def test_api_merge(http_client, base_url, nbdime_base_url, merge_validator, file
     assert json.dumps(data['base'], sort_keys=True) == json.dumps(expected_base, sort_keys=True)
     # Check that decisions follows schema:
     merge_validator.validate(data['merge_decisions'])
-
-
-@pytest.mark.timeout(timeout=WEB_TEST_TIMEOUT)

--- a/packages/nbdime/jest.config.js
+++ b/packages/nbdime/jest.config.js
@@ -1,14 +1,24 @@
-var tsConfig = require ('./tsconfig.json');
+var tsConfig = require('./tsconfig.json');
 
 var tsOptions = tsConfig["compilerOptions"];
 // Need as the test folder is not visible from the src folder
 tsOptions["rootDir"] = null;
 tsOptions["inlineSourceMap"] = true;
-//const jestJupyterLab = require('@jupyterlab/testutils/lib/jest-config');
-//const baseConfig = jestJupyterLab(__dirname);
+
+
+const esModules = [
+  '@jupyterlab',
+  '@codemirror',
+  '@jupyter/ydoc',
+  'lib0',
+  'nanoid',
+  'vscode-ws-jsonrpc',
+  'y-protocols',
+  'y-websocket',
+  'yjs'
+].join('|');
 
 module.exports = {
-  //...baseConfig,
   testEnvironment: 'jsdom',
   automock: false,
   moduleNameMapper: {
@@ -20,7 +30,7 @@ module.exports = {
   setupFiles: ['<rootDir>/test/jest-setup-files.js'],
   testPathIgnorePatterns: ['/lib/', '/node_modules/'],
   testRegex: '/test/src/.*.spec.ts$',
-  transformIgnorePatterns: ['/node_modules/(?!((@jupyterlab|y-protocols|yjs|@jupyter/ydoc|lib0)/.*))'],
+  transformIgnorePatterns: [`/node_modules/(?!${esModules}).+`],
   globals: {
     'ts-jest': {
       tsconfig: tsOptions

--- a/packages/nbdime/src/patch/stringified.ts
+++ b/packages/nbdime/src/patch/stringified.ts
@@ -205,7 +205,7 @@ function patchStringifiedObject(base: ReadonlyJSONObject, diff: IDiffObjectEntry
   // Object is dict. As diff keys should be unique, create map for easy processing
   let helper = new PatchObjectHelper(base, diff);
   let baseKeys = helper.baseKeys.slice();
-  for( const key of helper.keys()) {
+  for (const key of helper.keys()) {
     let keyString = _makeKeyString(key, level + 1);
     if (helper.isDiffKey(key)) {
       // Entry has a change

--- a/packages/nbdime/test/jest-setup-files.js
+++ b/packages/nbdime/test/jest-setup-files.js
@@ -1,2 +1,4 @@
 global.fetch = require('jest-fetch-mock');
 //global.crypto = require('crypto');
+
+global.DragEvent = class DragEvent {};

--- a/packages/nbdime/test/src/common/collapsiblepanel.spec.ts
+++ b/packages/nbdime/test/src/common/collapsiblepanel.spec.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-globalThis.DragEvent = class DragEvent {} as any;
-
 import {
   Widget
 } from '@lumino/widgets';

--- a/packages/nbdime/test/src/common/dragpanel.spec.ts
+++ b/packages/nbdime/test/src/common/dragpanel.spec.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-globalThis.DragEvent = class DragEvent {} as any;
-
 import {
     DragDropPanel
 } from '../../../src/common/dragpanel';

--- a/packages/nbdime/test/src/common/flexpanel.spec.ts
+++ b/packages/nbdime/test/src/common/flexpanel.spec.ts
@@ -1,15 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-globalThis.DragEvent = class DragEvent {} as any;
-
 import {
   Widget
 } from '@lumino/widgets';
-
-import {
-  each
-} from '@lumino/algorithm';
 
 import {
   FlexPanel
@@ -115,9 +109,9 @@ describe('upstreaming', () => {
       p.addWidget(new Widget());
       p.addWidget(new Widget());
       p.addWidget(new Widget());
-      each(p.widgets, (child) => {
+      for(const child of p.widgets) {
         expect(child.hasClass('p-FlexPanel-child')).toBe(true);
-      });
+      };
     });
 
     it('should remove child class name when removing a child widget', () => {

--- a/packages/nbdime/test/src/common/mergeview.spec.ts
+++ b/packages/nbdime/test/src/common/mergeview.spec.ts
@@ -1,31 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-globalThis.DragEvent = class DragEvent {} as any;
-
 import { MergeView } from '../../../src/common/mergeview';
 import { createDirectStringDiffModel } from '../../../src/diff/model/string';
-
-// Mock codemirror editor as it is provided by JupyterLab
-//  Note: the signal `selections.changed` must be mocked as it is connected
-//    to a slot in CodeEditorWrapper in @jupyterlab/codeeditor (see
-//    https://github.com/jupyterlab/jupyterlab/blob/4fc0a73336fe7bb92b2b2c0e6e8be89545086a50/packages/codeeditor/src/widget.ts#L51)
-jest.mock('@jupyterlab/codemirror', () => {
-  return {
-    CodeMirrorEditor: jest.fn(),
-    CodeMirrorEditorFactory: jest.fn().mockImplementation(() => {
-      return {
-        newInlineEditor: jest.fn().mockImplementation(() => {
-          return {
-            model: {
-              selections: { changed: { connect: jest.fn() } },
-            },
-          };
-        }),
-      };
-    }),
-  };
-});
 
 describe('common', () => {
   describe('MergeView', () => {

--- a/packages/nbdime/test/src/merge/model.spec.ts
+++ b/packages/nbdime/test/src/merge/model.spec.ts
@@ -21,9 +21,11 @@ import {
 } from '../../../src/merge/model';
 
 
-const notebook = require('../../files/base.ipynb.json') as nbformat.INotebookContent;
-const decisionsNB = require('../../files/decisionsA.json') as IMergeDecision[];
+import _notebook from '../../files/base.ipynb.json';
+import _decisionsNB from '../../files/decisionsA.json';
 
+const notebook: nbformat.INotebookContent = _notebook;
+const decisionsNB: IMergeDecision[] = _decisionsNB as IMergeDecision[];
 
 describe('merge', () => {
 

--- a/packages/nbdime/test/src/merge/widget.spec.ts
+++ b/packages/nbdime/test/src/merge/widget.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '@jupyterlab/rendermime';
 
 import {
-  defaultSanitizer
+  Sanitizer,
 } from '@jupyterlab/apputils';
 
 import type {
@@ -26,49 +26,16 @@ import {
 import {
     NotebookMergeWidget, MetadataMergeWidget
 } from '../../../src/merge/widget';
-import type { CodeEditor } from '@jupyterlab/codeeditor';
 
-
-const notebook = require('../../files/base.ipynb.json') as nbformat.INotebookContent;
-const NBdecisions = require('../../files/decisionsA.json') as IMergeDecision[];
-
-// Mock codemirror editor as it is provided by JupyterLab
-//  Notes:
-//    The signal `selections.changed` must be mocked as it is connected
-//    to a slot in CodeEditorWrapper in @jupyterlab/codeeditor
-//    See https://github.com/jupyterlab/jupyterlab/blob/4fc0a73336fe7bb92b2b2c0e6e8be89545086a50/packages/codeeditor/src/widget.ts#L51
-//
-//    Some method of the CodeMirror editor called when instantiating an editor in src/common/mergeview are also mocked.
-//    As these tests are only checking the widget instantiation, it is fine.
-jest.mock('@jupyterlab/codemirror', () => {
-  return {
-    CodeMirrorEditor: jest.fn(),
-    CodeMirrorEditorFactory: jest.fn().mockImplementation(() => {
-      return {
-        newInlineEditor: jest.fn().mockImplementation((options: CodeEditor.IOptions) => {
-          return {
-            model: {
-              selections: { changed: { connect: jest.fn() } },
-            },
-            editor: {
-              getValue: jest.fn().mockImplementation(() => options.model.sharedModel),
-              on: jest.fn(),
-              operation: jest.fn(),
-              state: {}
-            },
-          };
-        }),
-      };
-    }),
-  };
-});
+import notebook from '../../files/base.ipynb.json';
+import NBdecisions from '../../files/decisionsA.json';
 
 describe('merge', () => {
 
   describe('widget', () => {
 
     let rendermime = new RenderMimeRegistry({
-      initialFactories: standardRendererFactories, sanitizer: defaultSanitizer});
+      initialFactories: standardRendererFactories, sanitizer: new Sanitizer()});
 
     // End rendermime setup
 
@@ -96,7 +63,7 @@ describe('merge', () => {
     describe('NotebookMergeWidget', () => {
 
       it('should create a widget for a simple realistic model', () => {
-          let model = new NotebookMergeModel(notebook, NBdecisions);
+          let model = new NotebookMergeModel(notebook as nbformat.INotebookContent, NBdecisions as IMergeDecision[]);
           let widget = new NotebookMergeWidget(model, rendermime);
           expect(widget).not.toBe(null);
           Widget.attach(widget, document.body);

--- a/packages/nbdime/tsconfig.json
+++ b/packages/nbdime/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "types": ["jest"]
+    "types": ["jest"],
+    "resolveJsonModule": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This fixes the iterator issue, all failing JS tests, and all but one Python test.

Regarding the iterator issue: The lumino v1 `IIterator` interface was simultaneously an iterator and iterable (`IIterable`). The `each()` method on which usage I commented was calling `.iter()` method of `IIterable` to create an instantiated `IIterator`. Confusingly, these all were the same object, with implementation based on state modification. I simplified this behaviour while preserving the author intent and finished porting it to ES6 protocol.

- `clone()` was removed because it was a part of `IIterator` interface but is not a part ES6 iteration protocol
- removed mocks for JupyterLab CodeMirror implementation, these appear not needed
- moved `DragEvent` to setup files to avoid having it copy-pasted as needed
- removed deprecated `each` usage in tests
- ported json imports
- removed some old MathJax remnants