### PR TITLE
Disable auto-detection of language servers to reduce startup time

### DIFF
--- a/nbdime/tests/conftest.py
+++ b/nbdime/tests/conftest.py
@@ -506,6 +506,7 @@ def server_extension_app(tmpdir_factory, request):
          '--port=%i' % port,
         '--ip=127.0.0.1',
         '--log-level=DEBUG',
+        '--LanguageServerManager.autodetect=False',
         '--no-browser', '--%s.token=%s' % (token_config_location, TEST_TOKEN)],
         env=env)
 


### PR DESCRIPTION
Hi there! This appears to fix the last failing Python test. It was working locally and simply timing out on CI because search for language servers was taking long time on slow CI file system. This commit disables atuo-detection of language servers and it fixes the issue as seen https://github.com/krassowski/nbdime/pull/3.