### PR TITLE
Fix `lineChunks` and editor configuration, including `readOnly`

### DIFF
--- a/packages/nbdime/src/common/editor.ts
+++ b/packages/nbdime/src/common/editor.ts
@@ -75,7 +75,7 @@ constructor(value?: string, options?: Partial<CodeMirrorEditor.IOptions>) {
 
   super({
     model: model,
-    editorOptions: {config: {...options?.config, lineNumbers: true}},
+    editorOptions: options,
     factory: function() {
       let factory = new CodeMirrorEditorFactory({
         extensions,

--- a/packages/nbdime/src/common/editor.ts
+++ b/packages/nbdime/src/common/editor.ts
@@ -26,7 +26,7 @@ class EditorWidget extends CodeEditorWrapper {
    * need to loop over all instances.
    */
 
-constructor(value?: string, options?: CodeMirrorEditor.IOptions) {
+constructor(value?: string, options?: Partial<CodeMirrorEditor.IOptions>) {
   const sharedModel = new YFile();
   if (value) {
     sharedModel.source = value
@@ -75,7 +75,7 @@ constructor(value?: string, options?: CodeMirrorEditor.IOptions) {
 
   super({
     model: model,
-    editorOptions: {config: {lineNumbers: true}},
+    editorOptions: {config: {...options?.config, lineNumbers: true}},
     factory: function() {
       let factory = new CodeMirrorEditorFactory({
         extensions,

--- a/packages/nbdime/src/common/mergeview.ts
+++ b/packages/nbdime/src/common/mergeview.ts
@@ -401,7 +401,7 @@ export class DiffView {
     this._model = model;
     this._type = type;
     let remoteValue = this._model.remote || '';
-    this._remoteEditorWidget = new EditorWidget(remoteValue); // OPTIONS TO BE GIVEN
+    this._remoteEditorWidget = new EditorWidget(remoteValue, {config: options});
     this._remoteEditorWidget.editor.injectExtension([listener, mergeControlGutter, getCommonEditorExtensions()]);
   }
 
@@ -1026,7 +1026,7 @@ export class MergeView extends Panel {
         options.lineWrap = false;
       }
     }
-    this._base = new EditorWidget(options.value);
+    this._base = new EditorWidget(options.value, {config: options});
     this._base.editor.injectExtension([listener, mergeControlGutter, getCommonEditorExtensions()]);
     // START MERGE CASE
     if (merged) {
@@ -1144,7 +1144,9 @@ export class MergeView extends Panel {
       }
     }
     this._aligning = false;
-    this.scheduleAlignViews();
+    if (this._diffViews.length > 0) {
+      this.scheduleAlignViews();
+    }
   }
   /**
   * Align the matching lines of the different editors


### PR DESCRIPTION
This should fix the issue (1) and (2) from review; neither solution is ideal:
- we should probably avoid rendering hidden editors at all
- the `options` interface of `IMergeViewEditorConfiguration` should probably have `config: LegacyCodeMirror.IEditorConfiguration` entry rather than extend it

But for sake of getting a release out I think that these solutions are fine.

The last thing (apart from cell background CSS) that I would imagine to be a high priority before publishing a pre-release (possibly after merging the main PR) is adding a visual regression test for diffs covering more cases. Then we should go over the public API and clean it up before a final release.