### PR TITLE
Restore `getMergedValue()`, fix editor outline, remove unused class

### DIFF
--- a/packages/nbdime/src/common/mergeview.ts
+++ b/packages/nbdime/src/common/mergeview.ts
@@ -1247,6 +1247,13 @@ export class MergeView extends Panel {
       }
     }
 
+  getMergedValue(): string {
+    if (!this.merge) {
+      throw new Error('No merged value; missing "merged" view');
+    }
+    return this.merge.baseEditorWidget.model.sharedModel.getSource();
+  }
+
   /**
   * Actions and updates performed when a gutter marker is clicked
   */

--- a/packages/nbdime/src/merge/widget/cell.ts
+++ b/packages/nbdime/src/merge/widget/cell.ts
@@ -126,16 +126,14 @@ class CellMergeWidget extends Panel {
 
   validateMerged(candidate: nbformat.ICell): nbformat.ICell {
     if (this.sourceView && this.sourceView instanceof MergeView) {
-      /*let text = this.sourceView.getMergedValue();*/
-      let text = '';
+      let text = (this.sourceView as MergeView).getMergedValue();
       let lines = splitLines(text);
       if (candidate.source !== lines) {
         candidate.source = lines;
       }
     }
     if (this.metadataView && this.metadataView instanceof MergeView) {
-      /*let text = this.metadataView.getMergedValue();*/
-      let text = '';
+      let text = (this.sourceView as MergeView).getMergedValue();
       if (JSON.stringify(candidate.metadata) !== text) {
         // This will need to be validated server side,
         // and should not be touched by client side

--- a/packages/nbdime/src/styles/diff.css
+++ b/packages/nbdime/src/styles/diff.css
@@ -196,14 +196,14 @@
   background-color: var(--jp-diff-added-color2);
 }
 
-.jp-Notebook-diff .jp-Diff-deleted .CodeMirror,
+.jp-Notebook-diff .cm-merge-pane-deleted > .cm-editor,
 .jp-Notebook-diff .jp-Diff-deleted .jp-Diff-renderedOutput,
 .jp-Cellrow-outputs .jp-Diff-twoway .jp-Diff-base {
   background-color: var(--jp-diff-deleted-color2);
   border: solid 1px var(--jp-diff-deleted-color0);
 }
 
-.jp-Notebook-diff .jp-Diff-added .CodeMirror,
+.jp-Notebook-diff .cm-merge-pane-added > .cm-editor,
 .jp-Notebook-diff .jp-Diff-added .jp-Diff-renderedOutput,
 .jp-Cellrow-outputs .jp-Diff-twoway .jp-Diff-remote {
   background-color: var(--jp-diff-added-color2);
@@ -213,14 +213,6 @@
 .jp-Notebook-diff .jp-Diff-added .cm-merge-pane-added,
 .jp-Notebook-diff .jp-Diff-deleted .cm-merge-pane-deleted {
   width: 100%;
-}
-
-.jp-Notebook-diff .cm-merge-pane-added > .cm-editor {
-  background-color: var(--jp-diff-added-color2);
-}
-
-.jp-Notebook-diff .cm-merge-pane-deleted > .cm-editor {
-  background-color: var(--jp-diff-deleted-color2);
 }
 
 .jp-Notebook-diff .jp-Cellrow-source .jp-InputPrompt {


### PR DESCRIPTION
Two minor changes @HaudinFlorence.